### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ let color = UIColor(hue: 360.0, saturation: 100.0, lightness: l00.0, alpha: 1.0)
 
 ## INSTALL
 
-This project is compatible with Cocoapods and Carthage. (These instructions assume that your chosen method is already installed.)
+This project is compatible with CocoaPods and Carthage. (These instructions assume that your chosen method is already installed.)
 
-### Cocoapods
+### CocoaPods
 
-Add `pod 'HUSLSwift'` to your target. Since this is a Swift dynamic framework, you must also tell Cocoapods to `use_frameworks!` instead of static libraries.
+Add `pod 'HUSLSwift'` to your target. Since this is a Swift dynamic framework, you must also tell CocoaPods to `use_frameworks!` instead of static libraries.
 
 ```ruby
 platform :ios, '8.0' # or, :osx, '10.10'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
