### PR TITLE
Allows initializing UIColor or NSColor from HPLuv values

### DIFF
--- a/Extensions/AppKit/NSColor+extensions.swift
+++ b/Extensions/AppKit/NSColor+extensions.swift
@@ -25,6 +25,7 @@
 import AppKit
 
 public extension NSColor {
+
   /// Initializes and returns a color object using the specified opacity and
   /// HSLuv color space component values.
   ///
@@ -36,4 +37,17 @@ public extension NSColor {
     let rgb = hsluvToRgb(HSLuvTuple(hue, saturation, lightness))
     self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
   }
+
+    /// Initializes and returns a color object using the specified opacity and
+    /// HPLuv color space component values.
+    ///
+    /// - parameter hue: Double
+    /// - parameter pastelSaturation: Double
+    /// - parameter lightness: Double
+    /// - parameter alpha: Double
+    convenience init(hue: Double, pastelSaturation: Double, lightness: Double, alpha: Double) {
+      let rgb = hpluvToRgb(HSLuvTuple(hue, pastelSaturation, lightness))
+      self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
+    }
+
 }

--- a/Extensions/UIKit/UIKit+extensions.swift
+++ b/Extensions/UIKit/UIKit+extensions.swift
@@ -25,6 +25,7 @@
 import UIKit
 
 public extension UIColor {
+
   /// Initializes and returns a color object using the specified opacity and
   /// HSLuv color space component values.
   ///
@@ -36,4 +37,17 @@ public extension UIColor {
     let rgb = hsluvToRgb(HSLuvTuple(hue, saturation, lightness))
     self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
   }
+
+    /// Initializes and returns a color object using the specified opacity and
+    /// HPLuv color space component values.
+    ///
+    /// - parameter hue: Double
+    /// - parameter pastelSaturation: Double
+    /// - parameter lightness: Double
+    /// - parameter alpha: Double
+    convenience init(hue: Double, pastelSaturation: Double, lightness: Double, alpha: Double) {
+      let rgb = hpluvToRgb(HSLuvTuple(hue, pastelSaturation, lightness))
+      self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
+    }
+
 }

--- a/HSLuvSwift.xcodeproj/project.pbxproj
+++ b/HSLuvSwift.xcodeproj/project.pbxproj
@@ -360,7 +360,6 @@
 					};
 					CB6AB27E1B3083890075AF04 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = 2627WG76ES;
 						LastSwiftMigration = 0920;
 						ProvisioningStyle = Automatic;
 					};
@@ -370,7 +369,6 @@
 					};
 					CB98BFB31B307B070027506A = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = 2627WG76ES;
 						LastSwiftMigration = 0920;
 					};
 					CBDA801B1B2D2C740010C653 = {
@@ -588,10 +586,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 2627WG76ES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.claysmith.HSLuvMacTests;
@@ -606,10 +604,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 2627WG76ES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.claysmith.HSLuvMacTests;
@@ -625,6 +623,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -643,6 +642,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -661,9 +661,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 2627WG76ES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.claysmith.HSLuvTests;
@@ -677,9 +677,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 2627WG76ES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.claysmith.HSLuvTests;

--- a/HSLuvSwift.xcodeproj/project.pbxproj
+++ b/HSLuvSwift.xcodeproj/project.pbxproj
@@ -355,7 +355,7 @@
 				TargetAttributes = {
 					CB37B9041B2E7994009E63A5 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1130;
 						ProvisioningStyle = Automatic;
 					};
 					CB6AB27E1B3083890075AF04 = {
@@ -366,7 +366,7 @@
 					};
 					CB6AB2A01B308A6F0075AF04 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1130;
 					};
 					CB98BFB31B307B070027506A = {
 						CreatedOnToolsVersion = 7.0;
@@ -385,6 +385,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = CBDA80121B2D2C740010C653;
@@ -549,7 +550,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv7 armv7s";
 			};
@@ -576,7 +577,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = "arm64 armv7 armv7s";
@@ -632,7 +633,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = "arm64 armv7 armv7s";
 			};
 			name = Debug;
@@ -650,7 +651,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = "arm64 armv7 armv7s";
 			};

--- a/HSLuvSwift.xcodeproj/xcshareddata/xcschemes/HSLuviOS.xcscheme
+++ b/HSLuvSwift.xcodeproj/xcshareddata/xcschemes/HSLuviOS.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CB37B9041B2E7994009E63A5"
+            BuildableName = "HSLuvSwift.framework"
+            BlueprintName = "HSLuviOS"
+            ReferencedContainer = "container:HSLuvSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CB37B9041B2E7994009E63A5"
-            BuildableName = "HSLuvSwift.framework"
-            BlueprintName = "HSLuviOS"
-            ReferencedContainer = "container:HSLuvSwift.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:HSLuvSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Source/Math.swift
+++ b/Source/Math.swift
@@ -359,3 +359,11 @@ func hsluvToRgb(_ hsl: HSLuvTuple) -> RGBTuple {
 func rgbToHsluv(_ rgb: RGBTuple) -> HSLuvTuple {
     return lchToHsluv(luvToLch(xyzToLuv(rgbToXyz(rgb))))
 }
+
+func hpluvToRgb(_ hsl: HSLuvTuple) -> RGBTuple {
+    return xyzToRgb(luvToXyz(lchToLuv(hpluvToLch(hsl))))
+}
+
+func rgbToHpluv(_ rgb: RGBTuple) -> HSLuvTuple {
+    return lchToHpluv(luvToLch(xyzToLuv(rgbToXyz(rgb))))
+}

--- a/Tests/Snapshot.swift
+++ b/Tests/Snapshot.swift
@@ -52,13 +52,15 @@ class Snapshot {
             let luv = xyzToLuv(xyz)
             let lch = luvToLch(luv)
             let hsluv = lchToHsluv(lch)
+            let hpluv = lchToHpluv(lch)
 
             current[sample] = [
                 "rgb": [rgb.R, rgb.G, rgb.B],
                 "xyz": [xyz.X, xyz.Y, xyz.Z],
                 "luv": [luv.L, luv.U, luv.V],
                 "lch": [lch.L, lch.C, lch.H],
-                "hsluv": [hsluv.H, hsluv.S, hsluv.L]
+                "hsluv": [hsluv.H, hsluv.S, hsluv.L],
+                "hpluv": [hpluv.H, hpluv.S, hpluv.L]
             ]
         }
 
@@ -74,10 +76,6 @@ class Snapshot {
             }
 
             tags: for (tag, stableTuple) in stableSamples {
-                if tag == "hpluv" {
-                    continue tags
-                }
-
                 guard let currentTuple = currentSamples[tag] else {
                     fatalError("Current tuple is missing at \(hex):\(tag)")
                 }


### PR DESCRIPTION
To differentiate from HSLuv's init extensions the signature for HPLuv's init is 
`init(hue:, pastelSaturation:, lightness:, alpha: )`

In addition:
- Adds HPLuv shortcuts to Math.swift: hpluvToRgb, rgbToHpluv
- Removes development team from macOS test frameworks
- Passes Snapshot tests for HPLuv values
- Sets Swift version to 5