### PR TITLE
Expose HSLuv and HPLuv components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: objective-c
 osx_image: xcode11.3
 env:
   global:
-    - IOS_SDK=iphonesimulator11.2
-    - OSX_SDK=macosx10.13
+    - IOS_SDK=iphonesimulator13.2
+    - OSX_SDK=macosx10.15
   matrix:
     - SCHEME=HSLuvMac TEST_SDK=$OSX_SDK DESTINATION="arch=x86_64"
-    - SCHEME=HSLuviOS TEST_SDK=$IOS_SDK DESTINATION="OS=11.2,platform=iOS Simulator,id=9C4C0DDA-839D-4851-AA09-4382DB814A63"
+    - SCHEME=HSLuviOS TEST_SDK=$IOS_SDK DESTINATION="OS=13.2,platform=iOS Simulator,id=9C4C0DDA-839D-4851-AA09-4382DB814A63"
 script:
   - set -o pipefail
   - xcodebuild -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - OSX_SDK=macosx10.15
   matrix:
     - SCHEME=HSLuvMac TEST_SDK=$OSX_SDK DESTINATION="arch=x86_64"
-    - SCHEME=HSLuviOS TEST_SDK=$IOS_SDK DESTINATION="OS=13.2,platform=iOS Simulator,id=9C4C0DDA-839D-4851-AA09-4382DB814A63"
+    - SCHEME=HSLuviOS TEST_SDK=$IOS_SDK DESTINATION="OS=13.2,platform=iOS Simulator,id=8CD72926-1BD5-41EB-9045-03A9239A822F"
 script:
   - set -o pipefail
   - xcodebuild -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.2
+osx_image: xcode11.3
 env:
   global:
     - IOS_SDK=iphonesimulator11.2

--- a/Extensions/AppKit/NSColor+extensions.swift
+++ b/Extensions/AppKit/NSColor+extensions.swift
@@ -24,5 +24,15 @@
 
 import AppKit
 
-public extension NSColor: HSLuvInitializable {}
-public extension NSColor: HPLuvInitializable {}
+extension NSColor: HSLuvInitializable, HSLuvConvertible {
+
+    /// Convenience function to wrap the behavior of getRed(red:green:blue:alpha:)
+    public func getRGB() -> (red: CGFloat, green: CGFloat, blue: CGFloat) {
+        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return (red, green, blue)
+    }
+
+}
+
+extension NSColor: HPLuvInitializable, HPLuvConvertible {}

--- a/Extensions/AppKit/NSColor+extensions.swift
+++ b/Extensions/AppKit/NSColor+extensions.swift
@@ -25,6 +25,7 @@
 import AppKit
 
 public extension NSColor {
+
   /// Initializes and returns a color object using the specified opacity and
   /// HSLuv color space component values.
   ///
@@ -36,4 +37,17 @@ public extension NSColor {
     let rgb = hsluvToRgb(HSLuvTuple(hue, saturation, lightness))
     self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
   }
+
+    /// Initializes and returns a color object using the specified opacity and
+    /// HPLuv color space component values.
+    ///
+    /// - parameter hue: Double
+    /// - parameter pastelSaturation: Double
+    /// - parameter lightness: Double
+    /// - parameter alpha: Double
+    convenience init(hue: Double, pastelSaturation: Double, lightness: Double, alpha: Double) {
+      let rgb = hpluvToRgb(HSLuvTuple(hue, pastelSaturation, lightness))
+      self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
+    }
+
 }

--- a/Extensions/AppKit/NSColor+extensions.swift
+++ b/Extensions/AppKit/NSColor+extensions.swift
@@ -24,30 +24,5 @@
 
 import AppKit
 
-public extension NSColor {
-
-  /// Initializes and returns a color object using the specified opacity and
-  /// HSLuv color space component values.
-  ///
-  /// - parameter hue: Double
-  /// - parameter saturation: Double
-  /// - parameter lightness: Double
-  /// - parameter alpha: Double
-  convenience init(hue: Double, saturation: Double, lightness: Double, alpha: Double) {
-    let rgb = hsluvToRgb(HSLuvTuple(hue, saturation, lightness))
-    self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
-  }
-
-    /// Initializes and returns a color object using the specified opacity and
-    /// HPLuv color space component values.
-    ///
-    /// - parameter hue: Double
-    /// - parameter pastelSaturation: Double
-    /// - parameter lightness: Double
-    /// - parameter alpha: Double
-    convenience init(hue: Double, pastelSaturation: Double, lightness: Double, alpha: Double) {
-      let rgb = hpluvToRgb(HSLuvTuple(hue, pastelSaturation, lightness))
-      self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
-    }
-
-}
+public extension NSColor: HSLuvInitializable {}
+public extension NSColor: HPLuvInitializable {}

--- a/Extensions/UIKit/UIKit+extensions.swift
+++ b/Extensions/UIKit/UIKit+extensions.swift
@@ -24,5 +24,15 @@
 
 import UIKit
 
-extension UIColor: HSLuvInitializable {}
+extension UIColor: HSLuvInitializable {
+
+    /// Convenience function to wrap the behavior of getRed(red:green:blue:alpha:)
+    public func getRGB() -> (red: CGFloat, green: CGFloat, blue: CGFloat) {
+        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return (red, green, blue)
+    }
+
+}
+
 extension UIColor: HPLuvInitializable {}

--- a/Extensions/UIKit/UIKit+extensions.swift
+++ b/Extensions/UIKit/UIKit+extensions.swift
@@ -25,6 +25,7 @@
 import UIKit
 
 public extension UIColor {
+
   /// Initializes and returns a color object using the specified opacity and
   /// HSLuv color space component values.
   ///
@@ -36,4 +37,17 @@ public extension UIColor {
     let rgb = hsluvToRgb(HSLuvTuple(hue, saturation, lightness))
     self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
   }
+
+    /// Initializes and returns a color object using the specified opacity and
+    /// HPLuv color space component values.
+    ///
+    /// - parameter hue: Double
+    /// - parameter pastelSaturation: Double
+    /// - parameter lightness: Double
+    /// - parameter alpha: Double
+    convenience init(hue: Double, pastelSaturation: Double, lightness: Double, alpha: Double) {
+      let rgb = hpluvToRgb(HSLuvTuple(hue, pastelSaturation, lightness))
+      self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
+    }
+
 }

--- a/Extensions/UIKit/UIKit+extensions.swift
+++ b/Extensions/UIKit/UIKit+extensions.swift
@@ -24,30 +24,5 @@
 
 import UIKit
 
-public extension UIColor {
-
-  /// Initializes and returns a color object using the specified opacity and
-  /// HSLuv color space component values.
-  ///
-  /// - parameter hue: Double
-  /// - parameter saturation: Double
-  /// - parameter lightness: Double
-  /// - parameter alpha: Double
-  convenience init(hue: Double, saturation: Double, lightness: Double, alpha: Double) {
-    let rgb = hsluvToRgb(HSLuvTuple(hue, saturation, lightness))
-    self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
-  }
-
-    /// Initializes and returns a color object using the specified opacity and
-    /// HPLuv color space component values.
-    ///
-    /// - parameter hue: Double
-    /// - parameter pastelSaturation: Double
-    /// - parameter lightness: Double
-    /// - parameter alpha: Double
-    convenience init(hue: Double, pastelSaturation: Double, lightness: Double, alpha: Double) {
-      let rgb = hpluvToRgb(HSLuvTuple(hue, pastelSaturation, lightness))
-      self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
-    }
-
-}
+extension UIColor: HSLuvInitializable {}
+extension UIColor: HPLuvInitializable {}

--- a/Extensions/UIKit/UIKit+extensions.swift
+++ b/Extensions/UIKit/UIKit+extensions.swift
@@ -24,7 +24,7 @@
 
 import UIKit
 
-extension UIColor: HSLuvInitializable {
+extension UIColor: HSLuvInitializable, HSLuvConvertible {
 
     /// Convenience function to wrap the behavior of getRed(red:green:blue:alpha:)
     public func getRGB() -> (red: CGFloat, green: CGFloat, blue: CGFloat) {
@@ -35,4 +35,4 @@ extension UIColor: HSLuvInitializable {
 
 }
 
-extension UIColor: HPLuvInitializable {}
+extension UIColor: HPLuvInitializable, HPLuvConvertible {}

--- a/HSLuvSwift.xcodeproj/project.pbxproj
+++ b/HSLuvSwift.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		CBCAD5351B2F88AD00D0366A /* ColorEncodings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBCAD5331B2F88AB00D0366A /* ColorEncodings.swift */; };
 		CBDA80381B2D2CBF0010C653 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDA80361B2D2CBF0010C653 /* Constant.swift */; };
 		CBDA80391B2D2CBF0010C653 /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDA80371B2D2CBF0010C653 /* Math.swift */; };
+		DB6BA7CE23DDA9C100F1F964 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6BA7CD23DDA9C100F1F964 /* Protocols.swift */; };
+		DB6BA7CF23DDA9C100F1F964 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6BA7CD23DDA9C100F1F964 /* Protocols.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,6 +73,7 @@
 		CBDA80361B2D2CBF0010C653 /* Constant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Constant.swift; path = Source/Constant.swift; sourceTree = SOURCE_ROOT; };
 		CBDA80371B2D2CBF0010C653 /* Math.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Math.swift; path = Source/Math.swift; sourceTree = SOURCE_ROOT; };
 		CBDD2B131B461C3000E4548F /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		DB6BA7CD23DDA9C100F1F964 /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Protocols.swift; path = Source/Protocols.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -216,6 +219,7 @@
 				CBDA80361B2D2CBF0010C653 /* Constant.swift */,
 				CBCAD5331B2F88AB00D0366A /* ColorEncodings.swift */,
 				CBDA80371B2D2CBF0010C653 /* Math.swift */,
+				DB6BA7CD23DDA9C100F1F964 /* Protocols.swift */,
 				CB8B96C41B2D59C7000F303C /* Supporting Files */,
 			);
 			name = Source;
@@ -461,6 +465,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DB6BA7CF23DDA9C100F1F964 /* Protocols.swift in Sources */,
 				CB37B91C1B2E79A5009E63A5 /* Constant.swift in Sources */,
 				CBCAD5351B2F88AD00D0366A /* ColorEncodings.swift in Sources */,
 				CB37B91D1B2E79A8009E63A5 /* Math.swift in Sources */,
@@ -499,6 +504,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DB6BA7CE23DDA9C100F1F964 /* Protocols.swift in Sources */,
 				CBDA80381B2D2CBF0010C653 /* Constant.swift in Sources */,
 				CBCAD5341B2F88AB00D0366A /* ColorEncodings.swift in Sources */,
 				CBDA80391B2D2CBF0010C653 /* Math.swift in Sources */,

--- a/HSLuvSwift.xcodeproj/project.pbxproj
+++ b/HSLuvSwift.xcodeproj/project.pbxproj
@@ -360,7 +360,6 @@
 					};
 					CB6AB27E1B3083890075AF04 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = 2627WG76ES;
 						LastSwiftMigration = 0920;
 						ProvisioningStyle = Automatic;
 					};
@@ -370,7 +369,6 @@
 					};
 					CB98BFB31B307B070027506A = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = 2627WG76ES;
 						LastSwiftMigration = 0920;
 					};
 					CBDA801B1B2D2C740010C653 = {
@@ -588,10 +586,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 2627WG76ES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.claysmith.HSLuvMacTests;
@@ -606,10 +604,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 2627WG76ES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.claysmith.HSLuvMacTests;
@@ -625,6 +623,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -643,6 +642,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -661,9 +661,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 2627WG76ES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.claysmith.HSLuvTests;
@@ -677,9 +677,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 2627WG76ES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.claysmith.HSLuvTests;

--- a/HSLuvSwift.xcodeproj/project.pbxproj
+++ b/HSLuvSwift.xcodeproj/project.pbxproj
@@ -355,7 +355,7 @@
 				TargetAttributes = {
 					CB37B9041B2E7994009E63A5 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1130;
 						ProvisioningStyle = Automatic;
 					};
 					CB6AB27E1B3083890075AF04 = {
@@ -366,7 +366,7 @@
 					};
 					CB6AB2A01B308A6F0075AF04 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1130;
 					};
 					CB98BFB31B307B070027506A = {
 						CreatedOnToolsVersion = 7.0;
@@ -385,6 +385,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = CBDA80121B2D2C740010C653;
@@ -549,7 +550,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv7 armv7s";
 			};
@@ -576,7 +577,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = "arm64 armv7 armv7s";
@@ -632,7 +633,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = "arm64 armv7 armv7s";
 			};
 			name = Debug;
@@ -650,7 +651,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = "arm64 armv7 armv7s";
 			};

--- a/HSLuvSwift.xcodeproj/project.pbxproj
+++ b/HSLuvSwift.xcodeproj/project.pbxproj
@@ -602,7 +602,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -620,7 +620,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -675,7 +675,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.claysmith.HSLuvTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -691,7 +691,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.claysmith.HSLuvTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -748,6 +748,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = "";
 				VALID_ARCHS = "i386 x86_64";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -801,6 +802,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = "";
 				VALID_ARCHS = "i386 x86_64";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -828,7 +830,7 @@
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -852,7 +854,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/HSLuvSwift.xcodeproj/xcshareddata/xcschemes/HSLuviOS.xcscheme
+++ b/HSLuvSwift.xcodeproj/xcshareddata/xcschemes/HSLuviOS.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CB37B9041B2E7994009E63A5"
+            BuildableName = "HSLuvSwift.framework"
+            BlueprintName = "HSLuviOS"
+            ReferencedContainer = "container:HSLuvSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CB37B9041B2E7994009E63A5"
-            BuildableName = "HSLuvSwift.framework"
-            BlueprintName = "HSLuviOS"
-            ReferencedContainer = "container:HSLuvSwift.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:HSLuvSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Source/ColorEncodings.swift
+++ b/Source/ColorEncodings.swift
@@ -103,12 +103,12 @@ struct LCHTuple {
 }
 
 /// Hue(man), Saturation, Lightness (HSLuv)
-struct HSLuvTuple {
-    var H: Double
-    var S: Double
-    var L: Double
+public struct HSLuvTuple {
+    public var H: Double
+    public var S: Double
+    public var L: Double
 
-    init(_ H: Double, _ S: Double, _ L: Double) {
+    public init(_ H: Double, _ S: Double, _ L: Double) {
         self.H = H
         self.S = S
         self.L = L
@@ -116,12 +116,12 @@ struct HSLuvTuple {
 }
 
 /// Hue(man), Pastel saturation, Lightness (HPLuv)
-struct HPLuvTuple {
-    var H: Double
-    var P: Double
-    var L: Double
+public struct HPLuvTuple {
+    public var H: Double
+    public var P: Double
+    public var L: Double
 
-    init(_ H: Double, _ P: Double, _ L: Double) {
+    public init(_ H: Double, _ P: Double, _ L: Double) {
         self.H = H
         self.P = P
         self.L = L

--- a/Source/ColorEncodings.swift
+++ b/Source/ColorEncodings.swift
@@ -55,7 +55,7 @@ struct RGBTuple: TupleConverter {
     }
 
     var tuple: Tuple {
-        return (R, G, B)
+        (R, G, B)
     }
 }
 
@@ -72,7 +72,7 @@ struct XYZTuple: TupleConverter {
     }
 
     var tuple: Tuple {
-        return (X, Y, Z)
+        (X, Y, Z)
     }
 }
 
@@ -103,27 +103,35 @@ struct LCHTuple {
 }
 
 /// Hue(man), Saturation, Lightness (HSLuv)
-public struct HSLuvTuple {
-    public var H: Double
-    public var S: Double
-    public var L: Double
+struct HSLuvTuple: TupleConverter {
+    var H: Double
+    var S: Double
+    var L: Double
 
-    public init(_ H: Double, _ S: Double, _ L: Double) {
+    init(_ H: Double, _ S: Double, _ L: Double) {
         self.H = H
         self.S = S
         self.L = L
     }
+
+    var tuple: Tuple {
+        (H, S, L)
+    }
 }
 
 /// Hue(man), Pastel saturation, Lightness (HPLuv)
-public struct HPLuvTuple {
-    public var H: Double
-    public var P: Double
-    public var L: Double
+struct HPLuvTuple: TupleConverter {
+    var H: Double
+    var P: Double
+    var L: Double
 
-    public init(_ H: Double, _ P: Double, _ L: Double) {
+    init(_ H: Double, _ P: Double, _ L: Double) {
         self.H = H
         self.P = P
         self.L = L
+    }
+
+    var tuple: Tuple {
+        (H, P, L)
     }
 }

--- a/Source/ColorEncodings.swift
+++ b/Source/ColorEncodings.swift
@@ -114,3 +114,16 @@ struct HSLuvTuple {
         self.L = L
     }
 }
+
+/// Hue(man), Pastel saturation, Lightness (HPLuv)
+struct HPLuvTuple {
+    var H: Double
+    var P: Double
+    var L: Double
+
+    init(_ H: Double, _ P: Double, _ L: Double) {
+        self.H = H
+        self.P = P
+        self.L = L
+    }
+}

--- a/Source/Math.swift
+++ b/Source/Math.swift
@@ -359,3 +359,11 @@ func hsluvToRgb(_ hsl: HSLuvTuple) -> RGBTuple {
 func rgbToHsluv(_ rgb: RGBTuple) -> HSLuvTuple {
     return lchToHsluv(luvToLch(xyzToLuv(rgbToXyz(rgb))))
 }
+
+func hpluvToRgb(_ hsl: HSLuvTuple) -> RGBTuple {
+    return xyzToRgb(luvToXyz(lchToLuv(hpluvToLch(hsl))))
+}
+
+func rgbToHpluv(_ rgb: RGBTuple) -> HSLuvTuple {
+    return lchToHpluv(luvToLch(xyzToLuv(rgbToXyz(rgb))))
+}

--- a/Source/Math.swift
+++ b/Source/Math.swift
@@ -296,16 +296,16 @@ func hpluvToLch(_ hsluv: HSLuvTuple) -> LCHTuple {
     return LCHTuple(hsluv.L, C, hsluv.H)
 }
 
-func lchToHpluv(_ lch: LCHTuple) -> HSLuvTuple {
+func lchToHpluv(_ lch: LCHTuple) -> HPLuvTuple {
     guard lch.L <= 99.9999999 && lch.L >= 0.00000001 else {
         // White and black: disambiguate saturation
-        return HSLuvTuple(lch.H, 0, lch.L)
+        return HPLuvTuple(lch.H, 0, lch.L)
     }
 
     let max = maxChroma(lightness: lch.L)
     let S = lch.C / max * 100
 
-    return HSLuvTuple(lch.H, S, lch.L)
+    return HPLuvTuple(lch.H, S, lch.L)
 }
 
 // MARK: - RGB/Hex Conversion
@@ -364,6 +364,6 @@ func hpluvToRgb(_ hsl: HSLuvTuple) -> RGBTuple {
     return xyzToRgb(luvToXyz(lchToLuv(hpluvToLch(hsl))))
 }
 
-func rgbToHpluv(_ rgb: RGBTuple) -> HSLuvTuple {
+func rgbToHpluv(_ rgb: RGBTuple) -> HPLuvTuple {
     return lchToHpluv(luvToLch(xyzToLuv(rgbToXyz(rgb))))
 }

--- a/Source/Protocols.swift
+++ b/Source/Protocols.swift
@@ -60,14 +60,6 @@ extension HSLuvInitializable {
         self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
     }
 
-    /// Initializes and returns a color object using the specified HSLuv tuple
-    ///
-    /// - parameter hsluv: HSLuvTuple
-    /// - parameter alpha: Double
-    init(_ hsluv: HSLuvTuple, alpha: Double = 1) {
-        self.init(hue: hsluv.H, saturation: hsluv.S, lightness: hsluv.L, alpha: alpha)
-    }
-
 }
 
 public protocol HPLuvInitializable: Color {}
@@ -83,14 +75,6 @@ extension HPLuvInitializable {
     public init(hue: Double, pastelSaturation: Double, lightness: Double, alpha: Double) {
         let rgb = hpluvToRgb(HSLuvTuple(hue, pastelSaturation, lightness))
         self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
-    }
-
-    /// Initializes and returns a color object using the specified HPLuv tuple
-    ///
-    /// - parameter hsluv: HPLuvTuple
-    /// - parameter alpha: Double
-    init(_ hpluv: HPLuvTuple, alpha: Double = 1) {
-        self.init(hue: hpluv.H, pastelSaturation: hpluv.P, lightness: hpluv.L, alpha: alpha)
     }
 
 }

--- a/Source/Protocols.swift
+++ b/Source/Protocols.swift
@@ -26,12 +26,27 @@ import CoreGraphics
 
 // Abstracts NSColor / UIColor
 public protocol Color {
+
     init(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
+
+    /// Convenience function to wrap the behavior of getRed(red:green:blue:alpha:)
+    func getRGB() -> (red: CGFloat, green: CGFloat, blue: CGFloat)
+
 }
 
-public protocol HSLuvInitializable: Color {}
+extension Color {
 
-public extension HSLuvInitializable {
+    func getRGBTuple() -> RGBTuple {
+        let (red, green, blue) = getRGB()
+        return RGBTuple(Double(red), Double(green), Double(blue))
+    }
+
+}
+
+// MARK: - Initialization protocols
+
+public protocol HSLuvInitializable: Color {}
+extension HSLuvInitializable {
 
     /// Initializes and returns a color object using the specified opacity and
     /// HSLuv color space component values.
@@ -40,7 +55,7 @@ public extension HSLuvInitializable {
     /// - parameter saturation: Double
     /// - parameter lightness: Double
     /// - parameter alpha: Double
-    init(hue: Double, saturation: Double, lightness: Double, alpha: Double) {
+    public init(hue: Double, saturation: Double, lightness: Double, alpha: Double) {
         let rgb = hsluvToRgb(HSLuvTuple(hue, saturation, lightness))
         self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
     }
@@ -56,8 +71,7 @@ public extension HSLuvInitializable {
 }
 
 public protocol HPLuvInitializable: Color {}
-
-public extension HSLuvInitializable {
+extension HPLuvInitializable {
 
     /// Initializes and returns a color object using the specified opacity and
     /// HPLuv color space component values.
@@ -66,7 +80,7 @@ public extension HSLuvInitializable {
     /// - parameter pastelSaturation: Double
     /// - parameter lightness: Double
     /// - parameter alpha: Double
-    init(hue: Double, pastelSaturation: Double, lightness: Double, alpha: Double) {
+    public init(hue: Double, pastelSaturation: Double, lightness: Double, alpha: Double) {
         let rgb = hpluvToRgb(HSLuvTuple(hue, pastelSaturation, lightness))
         self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
     }
@@ -76,7 +90,45 @@ public extension HSLuvInitializable {
     /// - parameter hsluv: HPLuvTuple
     /// - parameter alpha: Double
     init(_ hpluv: HPLuvTuple, alpha: Double = 1) {
-        self.init(hue: hpluv.H, saturation: hpluv.P, lightness: hpluv.L, alpha: alpha)
+        self.init(hue: hpluv.H, pastelSaturation: hpluv.P, lightness: hpluv.L, alpha: alpha)
+    }
+
+}
+
+// MARK: - To HSLuv HPLuv conversions
+
+extension HSLuvTuple {
+
+    init(_ color: Color) {
+        self = rgbToHsluv(color.getRGBTuple())
+    }
+
+}
+
+extension HPLuvTuple {
+
+    init(_ color: Color) {
+        self = rgbToHpluv(color.getRGBTuple())
+    }
+
+}
+
+public protocol HSLuvConvertible: Color {}
+extension HSLuvConvertible {
+
+    /// Returns the HSLuv color space component values for this color.
+    public func getHSLuv() -> (hue: Double, saturation: Double, lightness: Double) {
+        HSLuvTuple(self).tuple
+    }
+
+}
+
+public protocol HPLuvConvertible: Color {}
+extension HPLuvConvertible {
+
+    /// Returns the HPLuv color space component values for this color.
+    public func getHPLuv() -> (hue: Double, pastelSaturation: Double, lightness: Double) {
+        HPLuvTuple(self).tuple
     }
 
 }

--- a/Source/Protocols.swift
+++ b/Source/Protocols.swift
@@ -1,0 +1,82 @@
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 Alexei Boronine
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import CoreGraphics
+
+// Abstracts NSColor / UIColor
+public protocol Color {
+    init(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
+}
+
+public protocol HSLuvInitializable: Color {}
+
+public extension HSLuvInitializable {
+
+    /// Initializes and returns a color object using the specified opacity and
+    /// HSLuv color space component values.
+    ///
+    /// - parameter hue: Double
+    /// - parameter saturation: Double
+    /// - parameter lightness: Double
+    /// - parameter alpha: Double
+    init(hue: Double, saturation: Double, lightness: Double, alpha: Double) {
+        let rgb = hsluvToRgb(HSLuvTuple(hue, saturation, lightness))
+        self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
+    }
+
+    /// Initializes and returns a color object using the specified HSLuv tuple
+    ///
+    /// - parameter hsluv: HSLuvTuple
+    /// - parameter alpha: Double
+    init(_ hsluv: HSLuvTuple, alpha: Double = 1) {
+        self.init(hue: hsluv.H, saturation: hsluv.S, lightness: hsluv.L, alpha: alpha)
+    }
+
+}
+
+public protocol HPLuvInitializable: Color {}
+
+public extension HSLuvInitializable {
+
+    /// Initializes and returns a color object using the specified opacity and
+    /// HPLuv color space component values.
+    ///
+    /// - parameter hue: Double
+    /// - parameter pastelSaturation: Double
+    /// - parameter lightness: Double
+    /// - parameter alpha: Double
+    init(hue: Double, pastelSaturation: Double, lightness: Double, alpha: Double) {
+        let rgb = hpluvToRgb(HSLuvTuple(hue, pastelSaturation, lightness))
+        self.init(red: CGFloat(rgb.R), green: CGFloat(rgb.G), blue: CGFloat(rgb.B), alpha: CGFloat(alpha))
+    }
+
+    /// Initializes and returns a color object using the specified HPLuv tuple
+    ///
+    /// - parameter hsluv: HPLuvTuple
+    /// - parameter alpha: Double
+    init(_ hpluv: HPLuvTuple, alpha: Double = 1) {
+        self.init(hue: hpluv.H, saturation: hpluv.P, lightness: hpluv.L, alpha: alpha)
+    }
+
+}

--- a/Tests/MacExtensions/AppKit.swift
+++ b/Tests/MacExtensions/AppKit.swift
@@ -26,22 +26,6 @@ import Foundation
 import XCTest
 import HSLuvSwift
 
-extension NSColor {
-    /// Convenience function to wrap the behavior of getRed(red:green:blue:alpha:)
-    ///
-    /// - returns: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
-    func getRGB() -> (red: Double, green: Double, blue: Double, alpha: Double) {
-        var red: CGFloat = 0.0
-        var green: CGFloat = 0.0
-        var blue: CGFloat = 0.0
-        var alpha: CGFloat = 0.0
-
-        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-
-        return (red: Double(red), green: Double(green), blue: Double(blue), alpha: Double(alpha))
-    }
-}
-
 class AppKitTests: XCTestCase {
     let rgbRangeTolerance = 0.00000000001
 
@@ -54,7 +38,7 @@ class AppKitTests: XCTestCase {
                     XCTAssertNotNil(color)
 
                     let tRgb = color.getRGB()
-                    let rgb = [tRgb.red, tRgb.green, tRgb.blue]
+                    let rgb = [tRgb.red, tRgb.green, tRgb.blue].map { Double($0) }
 
                     for channel in rgb {
                         XCTAssertGreaterThan(channel, -rgbRangeTolerance, "HSLuv: \([h, s, l]) -> RGB: \(rgb)")

--- a/Tests/Snapshot.swift
+++ b/Tests/Snapshot.swift
@@ -60,7 +60,7 @@ class Snapshot {
                 "luv": [luv.L, luv.U, luv.V],
                 "lch": [lch.L, lch.C, lch.H],
                 "hsluv": [hsluv.H, hsluv.S, hsluv.L],
-                "hpluv": [hpluv.H, hpluv.S, hpluv.L]
+                "hpluv": [hpluv.H, hpluv.P, hpluv.L]
             ]
         }
 

--- a/Tests/Snapshot.swift
+++ b/Tests/Snapshot.swift
@@ -52,13 +52,15 @@ class Snapshot {
             let luv = xyzToLuv(xyz)
             let lch = luvToLch(luv)
             let hsluv = lchToHsluv(lch)
+            let hpluv = lchToHpluv(lch)
 
             current[sample] = [
                 "rgb": [rgb.R, rgb.G, rgb.B],
                 "xyz": [xyz.X, xyz.Y, xyz.Z],
                 "luv": [luv.L, luv.U, luv.V],
                 "lch": [lch.L, lch.C, lch.H],
-                "hsluv": [hsluv.H, hsluv.S, hsluv.L]
+                "hsluv": [hsluv.H, hsluv.S, hsluv.L],
+                "hpluv": [hpluv.H, hpluv.S, hpluv.L]
             ]
         }
 
@@ -74,10 +76,6 @@ class Snapshot {
             }
 
             tags: for (tag, stableTuple) in stableSamples {
-                if tag == "hpluv" {
-                    continue tags
-                }
-
                 guard let currentTuple = currentSamples[tag] else {
                     fatalError("Current tuple is missing at \(hex):\(tag)")
                 }

--- a/Tests/iOSExtensions/UIKit.swift
+++ b/Tests/iOSExtensions/UIKit.swift
@@ -26,22 +26,6 @@ import Foundation
 import XCTest
 import HSLuvSwift
 
-extension UIColor {
-    /// Convenience function to wrap the behavior of getRed(red:green:blue:alpha:)
-    ///
-    /// - returns: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
-    func getRGB() -> (red: Double, green: Double, blue: Double, alpha: Double) {
-        var red: CGFloat = 0.0
-        var green: CGFloat = 0.0
-        var blue: CGFloat = 0.0
-        var alpha: CGFloat = 0.0
-
-        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-
-        return (red: Double(red), green: Double(green), blue: Double(blue), alpha: Double(alpha))
-    }
-}
-
 class UIKitTests: XCTestCase {
     let rgbRangeTolerance = 0.00000000001
 
@@ -54,7 +38,7 @@ class UIKitTests: XCTestCase {
                     XCTAssertNotNil(color)
 
                     let tRgb = color.getRGB()
-                    let rgb = [tRgb.red, tRgb.green, tRgb.blue]
+                    let rgb = [tRgb.red, tRgb.green, tRgb.blue].map { Double($0) }
 
                     for channel in rgb {
                         XCTAssertGreaterThan(channel, -rgbRangeTolerance, "HSLuv: \([h, s, l]) -> RGB: \(rgb)")


### PR DESCRIPTION
### Allows initializing UIColor or NSColor from HPLuv values

To differentiate from HSLuv's init extensions the signature for HPLuv's init is

```
init(hue:, pastelSaturation:, lightness:, alpha:)
```

### Exposes HSLuv and HPLuv components from UIColor and NSColor

NSColor and UIColor have been extended with a method to get their HSLuv components:

```
func getHSLuv() -> (hue: Double, saturation: Double, lightness: Double)
```

NSColor and UIColor have also been extended with a method to get their HPLuv components:

```
func getHPLuv() -> (hue: Double, pastelSaturation: Double, lightness: Double)
```

### In addition

- Removes development team from macOS test frameworks
- Passes Snapshot tests for HPLuv values
- Sets Swift version to 5
- Increments Travis CI XCode's version to 11.3