### PR TITLE
added SwiftUI.Color initializers

### DIFF
--- a/Sources/HSLuvSwift/Color+SwiftUI.swift
+++ b/Sources/HSLuvSwift/Color+SwiftUI.swift
@@ -1,0 +1,35 @@
+//
+//  File.swift
+//  HSLuvSwift
+//
+//  Created by Joseph Wardell on 3/8/25.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, visionOS 1.0, *)
+extension SwiftUI.Color {
+    
+    // SwiftUI.Color doesn't allow for accessing the raw RGB values
+    // without having access to the environment
+    // (see https://www.hackingwithswift.com/quick-start/swiftui/how-to-read-the-red-green-and-blue-values-from-a-color)
+    // so we cannot implement the framework's Color protocol
+    // we can only implement the initializer
+    public init(hue: Double, saturation: Double, lightness: Double, alpha: Double) {
+        let rgb = hsluvToRgb(HSLuvTuple(hue, saturation, lightness))
+
+        self.init(red: rgb.R, green: rgb.G, blue: rgb.B, opacity: alpha)
+    }
+    
+    // NOTE: SwiftUI.Color doesn't allow for accessing the raw RGB values
+    // without having access to the environment
+    // (see https://www.hackingwithswift.com/quick-start/swiftui/how-to-read-the-red-green-and-blue-values-from-a-color)
+    // so we cannot implement the framework's Color protocol
+    // we can only implement the initializer
+    public init(hue: Double, pastelSaturation: Double, lightness: Double, alpha: Double) {
+        let rgb = hpluvToRgb(HSLuvTuple(hue, pastelSaturation, lightness))
+
+        self.init(red: rgb.R, green: rgb.G, blue: rgb.B, opacity: alpha)
+    }
+
+}

--- a/Sources/HSLuvSwift/Color+SwiftUI.swift
+++ b/Sources/HSLuvSwift/Color+SwiftUI.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, visionOS 1.0, *)
 extension SwiftUI.Color {
-    
+
     // SwiftUI.Color doesn't allow for accessing the raw RGB values
     // without having access to the environment
     // (see https://www.hackingwithswift.com/quick-start/swiftui/how-to-read-the-red-green-and-blue-values-from-a-color)
@@ -20,7 +20,7 @@ extension SwiftUI.Color {
 
         self.init(red: rgb.R, green: rgb.G, blue: rgb.B, opacity: alpha)
     }
-    
+
     // NOTE: SwiftUI.Color doesn't allow for accessing the raw RGB values
     // without having access to the environment
     // (see https://www.hackingwithswift.com/quick-start/swiftui/how-to-read-the-red-green-and-blue-values-from-a-color)
@@ -31,5 +31,4 @@ extension SwiftUI.Color {
 
         self.init(red: rgb.R, green: rgb.G, blue: rgb.B, opacity: alpha)
     }
-
 }


### PR DESCRIPTION
Hello. Thanks so much for making this.

It's going to be super useful for me, but I did find it slightly inconvenient to use in my current environment, because I am writing a Multiplatform (non-catalyst) SwiftUi app.

So I added initializers for SwiftUI.Color to your package.

Thanks for writing this in a way that made it so simple to do.

There were some limitations I wish I could have overcome, see the comments.

Again, thanks.